### PR TITLE
Added some tests in CI on pull requests

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,25 @@
+name: Build and Test Docs
+
+on:
+  pull_request
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material
+
+      - name: Build documentation
+        run: |
+          mkdocs build --strict --config-file mkdocs_el.yml


### PR DESCRIPTION
Added tests into CI,
as we can see that there are many warnings related to issues with existing documentation. Because of that job failed with many warnings here: https://github.com/DmitriyStoyanov/projectalita.github.io/actions/runs/15664625451/job/44127096488
like that:

```
WARNING -  Doc file 'platform-documentation/menus/prompts.md' contains a link '../prompts/prompts-examples.md', but the target 'platform-documentation/prompts/prompts-examples.md' is not found among documentation files.
WARNING -  Doc file 'platform-documentation/menus/prompts.md' contains a link '../../manuals/alita-dial.md', but the target 'manuals/alita-dial.md' is not found among documentation files.
WARNING -  Doc file 'platform-documentation/menus/settings.md' contains a link '../user-guide/extensions/alita-code.md', but the target 'platform-documentation/user-guide/extensions/alita-code.md' is not found among documentation files.
WARNING -  Doc file 'release-notes/archived/rn1.md' contains a link '../user-guide/intro.md', but the target 'release-notes/user-guide/intro.md' is not found among documentation files.
WARNING -  Doc file 'release-notes/archived/rn2.md' contains a link '../user-guide/intro.md', but the target 'release-notes/user-guide/intro.md' is not found among documentation files.
```